### PR TITLE
Add markAsRead helper

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -101,7 +101,12 @@ if (currentUserId !== id1 && currentUserId !== id2 && req.user.role !== 'admin')
         return next({ status: 400, message: "Message ID is required." });
       }
 
-      const result = await MessageModel.markAsRead(messageId);
+      const numericId = Number(messageId);
+      if (isNaN(numericId)) {
+        return next({ status: 400, message: "Invalid message ID." });
+      }
+
+      const result = await MessageModel.markAsRead(numericId);
 
       if (result.code) {
         return next({ status: result.code, message: result.message });

--- a/models/MessageModel.js
+++ b/models/MessageModel.js
@@ -115,6 +115,20 @@ class MessageModel {
     }
   }
 
+  // UPDATE: Mark a single message as "seen" using its ID
+  async markAsRead(messageId) {
+    try {
+      const result = await this.db.query(
+        `UPDATE messages SET seen = 1 WHERE id = ?`,
+        [messageId]
+      );
+      return Array.isArray(result) ? result[0] : result;
+    } catch (err) {
+      console.error("Error in markAsRead:", err);
+      return { code: 500, message: 'Error marking message as read' };
+    }
+  }
+
   // READ: Get the inbox view (one most recent message per user pair)
   async getInboxForUser(userId) {
     try {


### PR DESCRIPTION
## Summary
- add `markAsRead` to `MessageModel`
- validate ID when marking message as read and use new model method

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688229422ca4832598375333ad0c0ee3